### PR TITLE
feat(rule): has-accessibility-hint is no longer include for basic preset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ export const rules = {
 }
 
 const basicRules = {
-  [`${PLUGIN_NAME}/has-accessibility-hint`]: 'error',
   [`${PLUGIN_NAME}/has-valid-accessibility-actions`]: 'error',
   [`${PLUGIN_NAME}/no-deprecated-props`]: 'error',
   [`${PLUGIN_NAME}/no-accessibilityLabel-for-testing`]: 'error',


### PR DESCRIPTION
Since `has-accessibility-hint` is a rule with many collisions, I temporarily excluded it from the preset.
The rule itself is still available.