### PR TITLE
fix(rule): image-has-accessible supported parent component #14

### DIFF
--- a/__tests__/rules/basic/image-has-accessible.test.ts
+++ b/__tests__/rules/basic/image-has-accessible.test.ts
@@ -14,6 +14,12 @@ ruleTester.run('image-has-accessible', imageHasAccessible, {
       code: `<View><Image accessible accessibilityLabel="React Native Logo" source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
     },
     {
+      code: `<View accessible accessibilityLabel="React Native Logo"><Image source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
+    },
+    {
+      code: `<TouchableOpacity accessible accessibilityRole="button" accessibilityLabel="Press Me" onPress={() => {}}><Image source={require('@expo/snack-static/react-native-logo.png')} /></TouchableOpacity>`,
+    },
+    {
       code: `<View><Image accessibilityLabel="React Native Logo" source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
       options: [
         {
@@ -43,6 +49,33 @@ ruleTester.run('image-has-accessible', imageHasAccessible, {
     },
     {
       code: `<View><Image accessibilityLabel="React Native Logo" source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
+      errors: [
+        {
+          message: 'Image should has `accessible` and `accessibilityLabel`',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: `<View accessible><Image source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
+      errors: [
+        {
+          message: 'Image should has `accessible` and `accessibilityLabel`',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: `<View accessible accessibilityLabel=""><Image source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
+      errors: [
+        {
+          message: 'Image should has `accessible` and `accessibilityLabel`',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: `<View><Image accessible accessibilityLabel="" source={require('@expo/snack-static/react-native-logo.png')} /></View>`,
       errors: [
         {
           message: 'Image should has `accessible` and `accessibilityLabel`',

--- a/docs/rules/basic/image-has-accessible.md
+++ b/docs/rules/basic/image-has-accessible.md
@@ -4,6 +4,8 @@
 
 It is recommended to use `accessibilityLabel` because the image will be recognizable by assistive technologies.
 
+**⚠️ NOTE:** This rule checks up to the parent of the target `Image`. It does not target ancestral elements to prevent nesting of elements with `accessible`.
+
 ## Type
 
 Warning
@@ -24,12 +26,32 @@ export const MaybeAccessibleComponent = () => {
 
 ```tsx
 export const MaybeAccessibleComponent = () => {
+  return (
+    <View>
+      <Image source={require('foo.jpg')} />
+    </View>
+  )
+}
+```
+
+```tsx
+export const MaybeAccessibleComponent = () => {
   // both `accessible` and `accessibilityLabel`, but no text.
   return <Image accessible accessibilityLabel="" source={require('foo.jpg')} />
 }
 ```
 
 ### Good
+
+```tsx
+export const MaybeAccessibleComponent = () => {
+  return (
+    <View accessible accessibilityLabel="Image of Foo.">
+      <Image source={require('foo.jpg')} />
+    </View>
+  )
+}
+```
 
 ```tsx
 export const MaybeAccessibleComponent = () => {

--- a/src/rules/basic/image-has-accessible.ts
+++ b/src/rules/basic/image-has-accessible.ts
@@ -2,11 +2,29 @@ import { createSchema, isTargetElement } from '../../utils'
 import { Rule } from 'eslint'
 import { getProp, getPropValue, hasEveryProp } from 'jsx-ast-utils'
 import { IMAGE, ACCESSIBLE, ACCESSIBILITY_LABEL } from '../../constants'
+import { JSXOpeningElement } from '../../types'
 
 const createErrorMessage = (isSupportedIos: boolean) =>
   `Image should has ${
     isSupportedIos ? `\`accessible\` and ` : ''
   }\`accessibilityLabel\``
+
+const checkProps = (node: JSXOpeningElement, targetProps: string[]) => {
+  /**
+   * First, check for `accessibleLabel`. Check `accessible` as well, depending on the option.
+   */
+  if (hasEveryProp(node.attributes, targetProps)) {
+    /**
+     * Even if the first condition is met, if `accessibleLabel` is an empty value, it will not be recognized. So check it.
+     */
+    if (!getPropValue(getProp(node.attributes, ACCESSIBILITY_LABEL))) {
+      return false
+    }
+    return true
+  } else {
+    return false
+  }
+}
 
 export const rule: Rule.RuleModule = {
   meta: {
@@ -19,22 +37,45 @@ export const rule: Rule.RuleModule = {
   create: (context) => ({
     JSXOpeningElement: (node) => {
       if (isTargetElement(node, context.options, [IMAGE], IMAGE)) {
+        /**
+         * if `isSupportedIos = true`, need check the `accessible` props too.
+         */
         const isSupportedIos: boolean =
           context.options[0]?.isSupportedIos ?? true
         const targetProps: string[] = [ACCESSIBILITY_LABEL]
-        // if `isSupportedIos = true`, need check the `accessible` props too.
         if (isSupportedIos) targetProps.push(ACCESSIBLE)
-        if (hasEveryProp(node.attributes, targetProps)) {
-          if (!getPropValue(getProp(node.attributes, ACCESSIBILITY_LABEL)))
+
+        // check on `Image`
+        const hasAccessiblePropsOnImage = checkProps(node, targetProps)
+
+        /**
+         * If the `Image` check is disabled, check the parent element.
+         * `Image` may be included as a child of `Touchable`.
+         * If the ancestor is accessible, we will only search for the parent here, in case it becomes inaccessible to the `View` that wraps the sibling `Image`.
+         */
+        if (!hasAccessiblePropsOnImage) {
+          const parentNode = node.parent?.parent?.openingElement
+            ? node.parent.parent.openingElement
+            : null
+          if (parentNode) {
+            // check on parent
+            const hasAccessiblePropsOnParent = checkProps(
+              parentNode,
+              targetProps,
+            )
+            if (!hasAccessiblePropsOnParent)
+              // Not valid if Props does not even exist in the parent of the inaccessible `Image`.
+              context.report({
+                node,
+                message: createErrorMessage(isSupportedIos),
+              })
+          } else {
+            // It is also invalid if the inaccessible `Image` has no parent.
             context.report({
               node,
               message: createErrorMessage(isSupportedIos),
             })
-        } else {
-          context.report({
-            node,
-            message: createErrorMessage(isSupportedIos),
-          })
+          }
         }
       }
     },

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -811,12 +811,13 @@ export type JSXClosingElement = {
   name: Node
 }
 
-export type JSXElement = {
-  // extends Node, Expression
-  children: JSXElement[]
-  closingElement?: JSXClosingElement
-  openingElement: JSXOpeningElement
-}
+export type JSXElement = Node &
+  Expression & {
+    children: JSXElement[]
+    closingElement?: JSXClosingElement
+    openingElement: JSXOpeningElement
+    parent?: JSXElement
+  }
 
 export type JSXEmptyExpression = {
   // extends Node, Expression


### PR DESCRIPTION
fixes #14 

image-has-accessible also supports parent elements.

This rule checks up to the parent of the target `Image`. It does not target ancestral elements to prevent nesting of elements with `accessible`.